### PR TITLE
Documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2013, the Scal Project Authors.
+Copyright (c) 2012-2016, the Scal Project Authors.
 All rights reserved. Please see the AUTHORS file for details.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ The following runs the Michael-Scott queue in a producer/consumer benchmark:
 
 And the same for the bounded-size k-FIFO queue:
 
-    ./prodcon-bskfifo -producers=15 -consumers=15 -operations=100000 -c=250
+    ./prodcon-bs-kfifo -producers=15 -consumers=15 -operations=100000 -c=250
 
 And for Distributed Queue with a 1-random balancer:
 
-    ./prodcon-dq-1random -producers=15 -consumers=15 -operations=100000 -c=250
+    ./prodcon-dds-1random-ms -producers=15 -consumers=15 -operations=100000 -c=250
 
 
 Try `./prodcon-<data_structure> --help` to see the full list of available parameters.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Paper: [Scal: A Benchmarking Suite for Concurrent Data Structures](./paper.pdf)
 * [gflags](https://code.google.com/p/gflags/ "gflags")
 * [google-perftools](https://code.google.com/p/gperftools/ "google-perftools")
 
+On debian (jessie) based systems:
+
+    sudo apt-get install build-essential autoconf libtool google-perftools libgoogle-perftools-dev cmake libgtest-dev libgflags2 libgflags-dev
+
 On Ubuntu (&ge; 12.04) based systems:
 
     sudo apt-get install build-essential autoconf libtool google-perftools libgoogle-perftools-dev cmake libgtest-dev

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Try `./prodcon-<data_structure> --help` to see the full list of available parame
 
 ## License
 
-Copyright (c) 2012-2013, the Scal Project Authors.
+Copyright (c) 2012-2016, the Scal Project Authors.
 All rights reserved. Please see the AUTHORS file for details.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
When trying out Scal I encountered a few things in the documentation that seemed out of date:
  * The packages are all available on debian jessie
  * some binary names used in the example do not exist
  * the copyright year is not up-to-date

Please feel free to cherry-pick the commits you like instead of using this pull-request.