### PR TITLE
add missing  function call statement

### DIFF
--- a/src/datastructures/wf_queue_ppopp12.h
+++ b/src/datastructures/wf_queue_ppopp12.h
@@ -234,7 +234,7 @@ void WaitfreeQueue<T>::help_if_needed() {
         help_deq(rec->cur_thread_id(), rec->last_phase());
       }
     }
-	rec->reset();
+    rec->reset();
   }
 }
 

--- a/src/datastructures/wf_queue_ppopp12.h
+++ b/src/datastructures/wf_queue_ppopp12.h
@@ -234,6 +234,7 @@ void WaitfreeQueue<T>::help_if_needed() {
         help_deq(rec->cur_thread_id(), rec->last_phase());
       }
     }
+	rec->reset();
   }
 }
 


### PR DESCRIPTION
If this function call is missing, the helping mechanism does not work.